### PR TITLE
Enhancement: add package data for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"
 readme = "README.rst"
 homepage = "https://jolly-good-toolbelt.github.io/tableread/"
+documentation = "https://jolly-good-toolbelt.github.io/tableread/"
 repository = "https://github.com/jolly-good-toolbelt/tableread"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [tool.poetry]
 name = "tableread"
-version = "2.0.1"
+version = "2.0.2"
 description = "Table reader for simple reStructuredText tables"
 authors = ["Brad Brown <brad@bradsbrown.com>"]
 license = "MIT"
+readme = "README.rst"
+homepage = "https://jolly-good-toolbelt.github.io/tableread/"
+repository = "https://github.com/jolly-good-toolbelt/tableread"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
Adding pieces to `pyproject.toml` so that the `tableread` PyPI page will look more this [this one for jiratools](https://pypi.org/project/jiratools/) than the [current mostly-blank tableread one](https://pypi.org/project/tableread/)