### PR TITLE
Fix: split deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_deploy:
   - poetry build
 
 deploy:
-  provider: script
-  script: ghp-import -p docs/ && poetry publish
-  skip_cleanup: true
+  - provider: script
+    script: ghp-import -p docs/
+    skip_cleanup: true
+  - provider: script
+    script: poetry publish
+    skip_cleanup: true


### PR DESCRIPTION
This way, if either fails, the other should still try. Working on getting proper GH auth for this setup, but this should let us publish to PyPI in the meanwhile.