### PR TITLE
Fix: drop inheritance diagram from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@ TableRead
 TableRead is a script designed to read reStructredText (reST) `simple tables`_ from a file and convert them into Python objects.
 
 
-.. inheritance-diagram:: tableread
-   :parts: 1
-
 Quickstart
 ----------
 


### PR DESCRIPTION
We got a failure on `pypi` upload due to the inheritance diagram in the readme:
```
$ twine check dist/tableread-2.0.3.tar.gz
Checking distribution dist/tableread-2.0.3.tar.gz: Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 7: Error: Unknown directive type "inheritance-diagram".

.. inheritance-diagram:: tableread
   :parts: 1
```

For now, dropping the diagram:
```
$ twine check dist/tableread-2.0.3.tar.gz
Checking distribution dist/tableread-2.0.3.tar.gz: Passed
```

Potential FRFM candidate.