### PR TITLE
Enhancement: Ignore egg-info folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/
 _docs/
 dist/
+/*.egg-info/


### PR DESCRIPTION
A lot of people have this ignored in their global ignore, but in case
they don't explicitly ignore it here.